### PR TITLE
Switch off Twitchapps TMI Token Generator to recommended

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ const oauth = "OAUTH_TOKEN_HERE"; // may or may not include the 'oauth:' part
 
 ## Installation
 
-1. Get auth token from https://twitchapps.com/tmi
+1. Get auth token from https://twitchtokengenerator.com be sure to select bot token.
 2. Obtain the token
 3. Put it in auth.js, like so:
 


### PR DESCRIPTION
As Twitchapps TMI Token Generator is no longer in service I updated the docs to use the new recommended TMI token generator.